### PR TITLE
Creating React Native / Expo bridge

### DIFF
--- a/SecurionPay/Library/3dsecure/ThreeDAuthenticator.swift
+++ b/SecurionPay/Library/3dsecure/ThreeDAuthenticator.swift
@@ -8,7 +8,7 @@ internal final class ThreeDAuthenticator {
         token: Token,
         amount: Int,
         currency: String,
-        navigationControllerFor3DS: UINavigationController,
+        navigationControllerFor3DS: UIViewController,
         bundleIdentifier: String?,
         completion: @escaping (Token?, SecurionPayError?) -> Void) {
             self.apiProvider.threeDSecureCheck(token: token, amount: amount, currency: currency) { [weak self] initResponse, initializationError in

--- a/SecurionPay/Library/SecurionPay.swift
+++ b/SecurionPay/Library/SecurionPay.swift
@@ -50,7 +50,7 @@ public final class SecurionPay: NSObject {
         token: Token,
         amount: Int,
         currency: String,
-        navigationControllerFor3DS: UINavigationController,
+        navigationControllerFor3DS: UIViewController,
         completion: @escaping (Token?, SecurionPayError?) -> Void) {
             checkIsConfigured()
             guard !busy else {


### PR DESCRIPTION
I am writing a bridge for react native and expo. 
The purpose of the bridge is to use the SDK without ejecting the expo application.

I had some issues implementing the SDK for IOS because the parameter of the authenticate method need a UINavigationController.

The methods that request a UINavigationController are passing the parameter to method that only need a UIViewController.

Can the parameter type be changed !

Thanks in advance
